### PR TITLE
Fixed dmenu link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h3 align="center">
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/logos/exports/1544x1544_circle.png" width="100" alt="Logo"/><br/>
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
-	Catppuccin for <a href="git.suckless.org/dmenu">Dmenu</a>
+	Catppuccin for <a href="https://git.suckless.org/dmenu">Dmenu</a>
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
 </h3>
 


### PR DESCRIPTION
GitHub recognised it as a relative link. Adding https:// should fix this issue!